### PR TITLE
Change pip install package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ There is work being done to remove these restrictions.
 Use pip if you can:
 
 ```bash
-pip install cq
+pip install django-cq
 ```
 
 or live on the edge:


### PR DESCRIPTION
Since `cq` on PyPI is another package