### PR TITLE
provide renderer passthrough to super on FuncNameWidget

### DIFF
--- a/cq/task.py
+++ b/cq/task.py
@@ -177,8 +177,8 @@ class FuncNameWidget(forms.TextInput):
         self._list = sorted(list(TaskFunc.task_table.keys()))
         self.attrs.update({'list': 'list__%s' % self._name})
 
-    def render(self, name, value, attrs=None):
-        text_html = super().render(name, value, attrs=attrs)
+    def render(self, name, value, attrs=None, renderer=None):
+        text_html = super().render(name, value, attrs=attrs, renderer=renderer)
         data_list = '<datalist id="list__%s">' % self._name
         for item in self._list:
             data_list += '<option value="%s">' % item


### PR DESCRIPTION
The renderer kwag was added to the widget render and _render functions that need supported in the FuncNameWidget render kwargs. This change is probably a breaking change for Django < 1.11. 

I'm currently attempting to get cq working with channels 2.1 on django 2.1 on python 3.7

What are the target supported versions for this module once full channels 2 support is added?